### PR TITLE
Window attribute distribution fix

### DIFF
--- a/eq/fabric/window.h
+++ b/eq/fabric/window.h
@@ -150,7 +150,13 @@ namespace fabric
 
         /** Set a window attribute. @version 1.0 */
         void setIAttribute( const IAttribute attr, const int32_t value )
-            { _data.iAttributes[attr] = value; }
+        { 
+			if(_data.iAttributes[attr] == value)
+				return;
+
+			_data.iAttributes[attr] = value;
+			setDirty(DIRTY_ATTRIBUTES); 
+		}
 
         /** @return the value of a window attribute. @version 1.0 */
         int32_t  getIAttribute( const IAttribute attr ) const


### PR DESCRIPTION
Window IAttributes are never distributed to the Server if they were set using the Admin interface because the dirty flag was missing. With this fix they are recognized as dirty and therefore correctly distributed by the Collage framework.

The same fix is already present in the main repo: 
https://github.com/Eyescale/Equalizer/commit/271f9df437dc7e360ac07044aef807f1775edacf#diff-cf7e7409fb77890d769ec62e0e92af71R293